### PR TITLE
Leverage IO::Buffer when available for decoding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,16 +34,22 @@ Metrics/ClassLength:
   Exclude:
   - 'spec/**/*'
   - 'lib/retf/decoder.rb'
+  - 'lib/retf/encoder.rb'
+  - 'lib/retf/decoder_fallback.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:
   - 'spec/**/*'
   - 'lib/retf/decoder.rb'
+  - 'lib/retf/encoder.rb'
+  - 'lib/retf/decoder_fallback.rb'
 
 Metrics/AbcSize:
   Exclude:
   - 'spec/**/*'
   - 'lib/retf/decoder.rb'
+  - 'lib/retf/encoder.rb'
+  - 'lib/retf/decoder_fallback.rb'
 
 RSpec/ExampleLength:
   Max: 50


### PR DESCRIPTION
While not available in all rubies benchmarks show that it gives anywhere from a 1.5x to 2x performance boost when decoding