### PR TITLE
add back in support for truffleruby

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,12 +16,7 @@ jobs:
         ruby: 
          - '3.2'
          - '3.3'
-          # Removed TruffleRuby due to
-          # a symbol not being defined error
-          # see https://github.com/oracle/truffleruby/issues/3697
-          #
-          # TODO: Uncomment when resolved
-         # - truffleruby
+         - truffleruby
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -38,12 +33,7 @@ jobs:
           ruby: 
            - '3.2'
            - '3.3'
-            # Removed TruffleRuby due to
-            # a symbol not being defined error
-            # see https://github.com/oracle/truffleruby/issues/3697
-            #
-            # TODO: Uncomment when resolved
-           # - truffleruby
+           - truffleruby
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/ext/retf_native/constants.h
+++ b/ext/retf_native/constants.h
@@ -10,6 +10,42 @@
 
 #define RETF_USIZE_MAX 4294967295
 
+// Since not all Rubies we want to support have
+// rb_str_strlen, we can work around this by
+// calling into Ruby to get the length of a
+// string in characters (different from bytes).
+#ifdef HAVE_RB_STR_STRLEN
+#define RETF_STR_LEN(s) rb_str_strlen(s)
+#else
+#define RETF_STR_LEN(s) NUM2LONG(rb_funcall(s, rb_intern("size"), 0))
+#endif
+
+// Another function not exported by all Rubies
+// we want to support is rb_mod_name.
+#ifdef HAVE_RB_MOD_NAME
+#define RETF_MOD_NAME(m) rb_mod_name(m)
+#else
+#define RETF_MOD_NAME(m) rb_funcall(m, rb_intern("name"), 0)
+#endif
+
+#ifdef HAVE_RB_BIG_EQ
+#define RETF_BIG_EQ(a, b) rb_big_eq(a, b)
+#else
+#define RETF_BIG_EQ(a, b) rb_funcall(a, rb_intern("=="), 1, b)
+#endif
+
+#ifdef HAVE_RB_BIG_AND
+#define RETF_BIG_AND(a, b) rb_big_and(a, b)
+#else
+#define RETF_BIG_AND(a, b) rb_funcall(a, rb_intern("&"), 1, b)
+#endif
+
+#ifdef HAVE_RB_BIG_RSHIFT
+#define RETF_BIG_RSHIFT(a, b) rb_big_rshift(a, b)
+#else
+#define RETF_BIG_RSHIFT(a, b) rb_funcall(a, rb_intern(">>"), 1, b)
+#endif
+
 void retf_constants_setup(VALUE mRetf);
 
 // Classes

--- a/ext/retf_native/encode.c
+++ b/ext/retf_native/encode.c
@@ -140,13 +140,13 @@ static VALUE encode_big_integer(VALUE bigint, VALUE str_buffer) {
 
   long len = 0;
 
-  while (!RTEST(rb_big_eq(bigint, INT2FIX(0)))) {
+  while (!RTEST(RETF_BIG_EQ(bigint, INT2FIX(0)))) {
     if (RB_TYPE_P(bigint, T_FIXNUM)) {
       break;
     }
 
-    char byte = FIX2INT(rb_big_and(bigint, INT2FIX(0xFF)));
-    bigint = rb_big_rshift(bigint, INT2FIX(8));
+    char byte = FIX2INT(RETF_BIG_AND(bigint, INT2FIX(0xFF)));
+    bigint = RETF_BIG_RSHIFT(bigint, INT2FIX(8));
 
     rb_str_cat(str, &byte, 1);
     len++;
@@ -394,7 +394,7 @@ static VALUE encode_atom(VALUE self, VALUE str_buffer) {
   size_t len = RSTRING_LEN(str);
   char *ptr = RSTRING_PTR(str);
 
-  if (rb_str_strlen(str) > 255) {
+  if (RETF_STR_LEN(str) > 255) {
     rb_raise(rb_eArgError,
              "atom is too long to encode, length must fit in "
              "a 32-bit unsigned integer");
@@ -425,7 +425,7 @@ VALUE retf_encode_class(int argc, VALUE *argv, VALUE self) {
 }
 
 static VALUE encode_class(VALUE self, VALUE str_buffer) {
-  VALUE name = rb_mod_name(self);
+  VALUE name = RETF_MOD_NAME(self);
 
   if (RB_NIL_P(name)) {
     rb_raise(rb_eArgError, "cannot encode an anonymous class");
@@ -438,7 +438,7 @@ static VALUE encode_class(VALUE self, VALUE str_buffer) {
                                 rb_str_new_lit("::"), rb_str_new_lit("."));
 
   // 7 is the length of "Elixir."
-  if (7 + rb_str_strlen(elixirized) > 255) {
+  if (7 + RETF_STR_LEN(elixirized) > 255) {
     rb_raise(rb_eArgError,
              "class name is too long to encode, must be no "
              "greater than 255 characters");

--- a/ext/retf_native/extconf.rb
+++ b/ext/retf_native/extconf.rb
@@ -5,7 +5,12 @@ require 'mkmf'
 # required for converting network byte order
 # to host byte order and vice versa
 abort('endian.h is required') unless have_header('endian.h')
-abort('rb_str_strlen is required') unless have_func('rb_str_strlen')
+
+have_func('rb_str_strlen')
+have_func('rb_mod_name')
+have_func('rb_big_eq')
+have_func('rb_big_and')
+have_func('rb_big_rshift')
 
 append_cflags('-flto')
 create_makefile('retf_native')


### PR DESCRIPTION
As was suggested, uses `#define`s and `#ifdef`s to fall back to `rb_funcall` when a symbol isn't available